### PR TITLE
Adding option for stream to start

### DIFF
--- a/src/stream.js
+++ b/src/stream.js
@@ -152,7 +152,7 @@ const initLiveStream = (options) => {
    * @param {string} publicId The public id of the video resource generated. This is the public-id returned from the
    * initLiveStream function.
    */
-  let start = function (publicId) {
+  let start = function (publicId, stream) {
     // before, after, during recording
     cld.send({
       "message": {
@@ -166,6 +166,7 @@ const initLiveStream = (options) => {
       {
         // By default, it's sendrecv for audio and video...
         media: {video: "hires"},
+        stream: stream,
         success: function (jsep) {
           Janus.debug("Got SDP!");
           Janus.debug(jsep);


### PR DESCRIPTION
Hi, 

This comes as a need to allow us to specify a custom stream option when calling liveStream.start

For example if we want to livestream the users screen:

```
async function startCapture(displayMediaOptions) {
        let captureStream = null;
        try {
            captureStream = await navigator.mediaDevices.getDisplayMedia(displayMediaOptions);
        } catch (err) {
            catchErrors(err, toast.error)
        }
        return captureStream;
    }


    async function startScreenShare() {
        let audioTrack, videoTrack;
        await startCapture({
            video: true
        }).then(async displayStream => {
            [videoTrack] = displayStream.getVideoTracks();
            const audioStream = await navigator.mediaDevices.getUserMedia({ audio: true }).catch(err => { catchErrors(err, toast.error); });
            [audioTrack] = audioStream.getAudioTracks();
            displayStream.addTrack(audioTrack); // do stuff
            return displayStream
        }).then(stream => liveStream.start(publicId, stream));
    }`